### PR TITLE
SCRIPT: Script to allow configuration with concurrency

### DIFF
--- a/scripts/wrapped_geth_dev.sh
+++ b/scripts/wrapped_geth_dev.sh
@@ -42,9 +42,9 @@ main() {
             fi
 
             # There must be no spaces in the JSON config string otherwise bash is not happy
-            json_config="{\"applyBackwardCompatibility\":${backward_compatibility},\"concurrentBlockFlushing\":false${forced_backward_compatibility}}"
+            json_config="{\"applyBackwardCompatibility\":${backward_compatibility},\"concurrentBlockFlushing\":${concurrent_block_flushing}${forced_backward_compatibility}}"
             echo "Using vmtrace.jsonconfig: $json_config"
-            geth_extra_args+=("--vmtrace.jsonconfig={\"applyBackwardCompatibility\":${backward_compatibility},\"concurrentBlockFlushing\":${concurrent_block_flushing}${forced_backward_compatibility}}")
+            geth_extra_args+=("--vmtrace.jsonconfig=$json_config")
         fi
     fi
 


### PR DESCRIPTION
## Changes Introduced
Configuration path to allow concurrency
- ./scripts/run_firehose_geth_dev.sh 3.0 prague (original config)
- CONCURRENT_BLOCK_FLUSHING=true ./scripts/run_firehose_geth_dev.sh 3.0 prague (with concurrency)

## Notes
- Related to PR https://github.com/streamingfast/go-ethereum/pull/14