### PR TITLE
SCRIPT: Updated script for multiple goroutines

### DIFF
--- a/scripts/wrapped_geth_dev.sh
+++ b/scripts/wrapped_geth_dev.sh
@@ -42,9 +42,9 @@ main() {
             fi
 
             # There must be no spaces in the JSON config string otherwise bash is not happy
-            json_config="{\"applyBackwardCompatibility\":${backward_compatibility},\"concurrentBlockFlushing\":false${forced_backward_compatibility}}"
+            json_config="{\"applyBackwardCompatibility\":${backward_compatibility},\"concurrentBlockFlushing\":${concurrent_block_flushing}${forced_backward_compatibility}}"
             echo "Using vmtrace.jsonconfig: $json_config"
-            geth_extra_args+=("--vmtrace.jsonconfig={\"applyBackwardCompatibility\":${backward_compatibility},\"concurrentBlockFlushing\":${concurrent_block_flushing}${forced_backward_compatibility}}")
+            geth_extra_args+=("--vmtrace.jsonconfig=$json_config")
         fi
     fi
 

--- a/scripts/wrapped_geth_dev.sh
+++ b/scripts/wrapped_geth_dev.sh
@@ -22,9 +22,10 @@ main() {
     fi
 
     # CONCURRENT_BLOCK_FLUSHING=true ./scripts/run_firehose_geth_dev.sh 3.0 prague
-    concurrent_block_flushing="false"
-    if [[ "$CONCURRENT_BLOCK_FLUSHING" == "true" ]]; then
-        concurrent_block_flushing="true"
+    concurrent_block_flushing="${CONCURRENT_BLOCK_FLUSHING:-0}"
+    if ! [[ "$concurrent_block_flushing" =~ ^[0-9]+$ ]]; then
+        echo "Invalid CONCURRENT_BLOCK_FLUSHING value: '$concurrent_block_flushing'. Must be a non-negative integer."
+        exit 1
     fi
 
     "$geth" --dev --datadir="$data_dir" "--gcmode=archive" "--state.scheme=hash" init "$ROOT/geth_dev/genesis.$fork_version.json" 2> /dev/null

--- a/scripts/wrapped_geth_dev.sh
+++ b/scripts/wrapped_geth_dev.sh
@@ -21,6 +21,12 @@ main() {
         exit 1
     fi
 
+    # CONCURRENT_BLOCK_FLUSHING=true ./scripts/run_firehose_geth_dev.sh 3.0 prague
+    concurrent_block_flushing="false"
+    if [[ "$CONCURRENT_BLOCK_FLUSHING" == "true" ]]; then
+        concurrent_block_flushing="true"
+    fi
+
     "$geth" --dev --datadir="$data_dir" "--gcmode=archive" "--state.scheme=hash" init "$ROOT/geth_dev/genesis.$fork_version.json" 2> /dev/null
 
     geth_extra_args=("--dev" "--dev.period=1" "--http" "--http.api=eth,web3,net" "--datadir=$data_dir" "--gcmode=archive" "--state.scheme=hash")
@@ -36,7 +42,9 @@ main() {
             fi
 
             # There must be no spaces in the JSON config string otherwise bash is not happy
-            geth_extra_args+=("--vmtrace.jsonconfig={\"applyBackwardCompatibility\":${backward_compatibility}${forced_backward_compatibility}}")
+            json_config="{\"applyBackwardCompatibility\":${backward_compatibility},\"concurrentBlockFlushing\":false${forced_backward_compatibility}}"
+            echo "Using vmtrace.jsonconfig: $json_config"
+            geth_extra_args+=("--vmtrace.jsonconfig={\"applyBackwardCompatibility\":${backward_compatibility},\"concurrentBlockFlushing\":${concurrent_block_flushing}${forced_backward_compatibility}}")
         fi
     fi
 


### PR DESCRIPTION
## Changes Introduced
Configuration path to allow multiple goroutines concurrency
- ./scripts/run_firehose_geth_dev.sh 3.0 prague (original config)
- CONCURRENT_BLOCK_FLUSHING=10 ./scripts/run_firehose_geth_dev.sh 3.0 prague (with concurrency)

## Notes
- Related to PR https://github.com/streamingfast/go-ethereum/pull/15